### PR TITLE
Add guarded account deletion modal

### DIFF
--- a/src/lib/l10n.csv
+++ b/src/lib/l10n.csv
@@ -54,7 +54,7 @@ debug-logs,Debug logs,调试日志,調試日誌,گزارش‌های عیب‌ی�
 debug-pack,Debug pack,调试包,調試包,بسته عیب یابی,Отладочный пакет
 debug-pack-blurb,Save debugging info for developers,保存调试信息以供开发人员使用,保存除錯資訊以供開發人員使用,ذخیره گزارش‌های عیب‌یابی برای توسعه‌دهندگان,Сохранить отладочную информацию для разработчиков
 delete,Delete,删除,刪除,حذف,Удалить
-delete-account,Delete account,刪除账户,刪除賬戶,حذف حساب کاربری,Удалить аккаунт
+delete-account,Delete account (tap 10x quickly),刪除账户(快速点10次),刪除賬戶(快速點10次),حذف حساب کاربری (۱۰ بار سریع بزنید),Удалить аккаунт (нажать 10 раз)
 delete-account-are-you-sure,Are you sure that you want to delete your account?,你确定要删除你的账户吗？,你確定要刪除你的賬戶嗎？,آیا مطمئن هستید که می‌خواهید اکانت خود را حذف کنید؟,Вы уверены, что хотите удалить свой аккаунт?
 delete-account-blurb,Permanently delete account,永久删除账户,永久刪除賬戶,حذف دائمی حساب کاربری,Безвозвратно удалить аккаунт
 direct,Direct,直连,直连,مستقیم,Прямой

--- a/src/lib/user.ts
+++ b/src/lib/user.ts
@@ -162,6 +162,11 @@ export const clearAccountCache = () => {
   account_refreshing.set(true);
 };
 
+export const clearAllCaches = () => {
+  clearAccountCache();
+  serverListCache.clear();
+};
+
 export const account_refreshing = writable(false);
 
 /**


### PR DESCRIPTION
## Summary
- prompt the user with a confirmation modal before actually deleting their account
- require tapping the delete-account button 10x quickly
- update `delete-account` text in translations
- clear JS caches via new helper when logging out or deleting account
- visually separate the delete button with a divider

## Testing
- `npm run check` *(fails: Property 'purge_caches' does not exist on type 'NativeGate')*