### PR TITLE
Add Basic plan purchase option

### DIFF
--- a/src/lib/l10n.csv
+++ b/src/lib/l10n.csv
@@ -198,3 +198,7 @@ streaming-tab,"Streaming","流媒体","流媒體","استریمینگ","Стри
 core-blurb,"Core servers have the best security and speed.","核心服务器具有最高的安全性和速度","核心伺服器具有最高的安全性和速度","سرورهای هسته برای امنیت و عملکرد بهینه شده‌اند.","Основные серверы оптимизированы для безопасности и производительности."
 streaming-blurb,"Streaming servers are recommended for streaming services.","流媒体服务器推荐用于流媒体服务","流媒體伺服器推薦用於流媒體服務","سرورهای استریمینگ برای خدمات پخش زنده توصیه می‌شوند.","Стриминговые серверы рекомендуются для потоковых сервисов."
 unlimited-bandwidth,Unlimited usage,无限用量,無限用量,پهنای باند نامحدود,Безлимитная пропускная способность
+unlimited-tab,Unlimited,无限,無限,نامحدود,Безлимит
+basic-tab,Basic,基础,Basic,ساده,Базовый
+bandwidth-limit-prefix,Bandwidth limit:,流量上限：,流量上限：,حد پهنای باند:,Лимит трафика:
+mb-per-month,MB/month,MB/月,MB/月,MB/ماه,МБ/мес

--- a/src/native-gate.ts
+++ b/src/native-gate.ts
@@ -48,14 +48,29 @@ export interface NativeGate {
   price_points(): Promise<[number, number][]>;
 
   /**
+   * Obtains the list of Basic price points
+   */
+  basic_price_points(): Promise<[number, number][]>;
+
+  /**
    * Create an invoice using a number of days
    */
   create_invoice(secret: string, days: number): Promise<InvoiceInfo>;
 
   /**
+   * Create a Basic invoice using a number of days
+   */
+  create_basic_invoice(secret: string, days: number): Promise<InvoiceInfo>;
+
+  /**
    * Pay an invoice with a given method
    */
   pay_invoice(id: string, method: string): Promise<void>;
+
+  /**
+   * Obtain Basic account rollout info
+   */
+  get_basic_info(secret: string): Promise<{ bw_limit: number } | null>;
 
   /**
    * Gets the list of apps
@@ -251,6 +266,14 @@ function mock_native_gate(): NativeGate {
       ];
     },
 
+    basic_price_points: async () => {
+      random_fail();
+      return [
+        [30, 2],
+        [60, 4],
+      ];
+    },
+
     async create_invoice(secret: string, days: number) {
       random_fail();
       await random_sleep();
@@ -260,9 +283,24 @@ function mock_native_gate(): NativeGate {
       };
     },
 
+    async create_basic_invoice(secret: string, days: number) {
+      random_fail();
+      await random_sleep();
+      return {
+        id: "foobar-basic",
+        methods: ["credit-card"],
+      };
+    },
+
     async pay_invoice(id: string, method: string) {
       random_fail();
       await random_sleep();
+    },
+
+    async get_basic_info(secret: string) {
+      random_fail();
+      await random_sleep();
+      return { bw_limit: 5000 };
     },
 
     async daemon_rpc(method, args) {


### PR DESCRIPTION
## Summary
- allow purchasing Basic or Unlimited plans
- mock native gate exposes Basic pricing and invoice functions
- show Basic/Unlimited tabs in plan selector
- localize new UI strings

## Testing
- `npm run check` *(fails: svelte-check found 25 errors)*

------
https://chatgpt.com/codex/tasks/task_b_6854a4d7c30c8333b7869de83bb2eeaa