### PR TITLE
Implement basic upgrade blurb

### DIFF
--- a/src/PaymentPopup.svelte
+++ b/src/PaymentPopup.svelte
@@ -7,6 +7,7 @@
     clearAccountCache,
     curr_valid_secret,
     paymentsOpen,
+    app_status,
   } from "./lib/user";
   import {
     ProgressBar,
@@ -45,6 +46,14 @@
   let payInProgress = false;
   let redeemInProgress = false;
   let voucherCode = "";
+  $: remainingBasicDays =
+    $app_status &&
+    $app_status.account.level === "Plus" &&
+    $app_status.account.bw_consumption
+      ? Math.ceil(
+          ($app_status.account.expiry - Math.floor(Date.now() / 1000)) / 86400,
+        )
+      : null;
   const modalStore = getModalStore();
   const toastStore = getToastStore();
 
@@ -176,6 +185,15 @@
                 l10n($curr_lang, "gb-per-month")
               : ""}
         </p>
+        {#if planTab === "unlimited" && remainingBasicDays !== null}
+          <p class="text-center text-xs mb-2 font-bold">
+            {l10n($curr_lang, "basic-upgrade-blurb-prefix")}
+            {remainingBasicDays}
+            {" "}
+            {l10n($curr_lang, "days")}
+            {l10n($curr_lang, "basic-upgrade-blurb-suffix")}
+          </p>
+        {/if}
       {/if}
       {#key planTab}
         {#await getPricePoints()}

--- a/src/lib/l10n.csv
+++ b/src/lib/l10n.csv
@@ -203,3 +203,5 @@ basic-tab,Basic,基础,Basic,ساده,Базовый
 bandwidth-limit-prefix,Bandwidth limit: ,流量上限：,流量上限：,حد پهنای باند: ,Лимит трафика: 
 mb-per-month,MB/month,MB/月,MB/月,MB/ماه,МБ/мес
 gb-per-month,GB/month,GB/月,GB/月,GB/ماه,GB/мес
+basic-upgrade-blurb-prefix,This will upgrade ,这将升级当前基础计划剩余,這將升級當前基礎方案剩餘,با ارتقا، ,Это обновит 
+basic-upgrade-blurb-suffix, days of your Basic plan at a lower price.,天，价格会更低。,天，價格會更低。, روز از طرح پایه شما و قیمت نهایی کمتر می‌شود., дней вашего базового плана, снизив цену.


### PR DESCRIPTION
## Summary
- show remaining Basic days message when selecting Unlimited plan
- add translations for the new blurb

## Testing
- `npm run check` *(fails: Property 'purge_caches' does not exist on type 'NativeGate' etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68555e29dc50833394a76562ed12e2a2